### PR TITLE
Add link to Docusaurus Example & Fix Heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ The `jupyter-react` library can be used in any React.js application. Install the
   <img alt="Jupyter React Slate" src="https://datalayer-jupyter-examples.s3.amazonaws.com/jupyter-react-notebook.png" />
 </div>
 
-We maintain a plugin for [Docusaurus](https://docusaurus.io) in the [docusaurus](https://github.com/datalayer/jupyter-react/tree/main/packages/docusaurus) package folder (see the [Docusaurus example]()).
+We maintain a plugin for [Docusaurus](https://docusaurus.io) in the [docusaurus](https://github.com/datalayer/jupyter-react/tree/main/packages/docusaurus) package folder (see the [Docusaurus example](https://github.com/datalayer/jupyter-react/tree/main/examples/docusaurus)).
 
 <div align="center" style="text-align: center">
   <img alt="Jupyter React Slate" src="https://datalayer-jupyter-examples.s3.amazonaws.com/jupyter-react-docusaurus.png" />
 </div>
+
 ## Literate Notebook
 
 > ✍️ A notebook for literate programming, compatible with Jupyter and ObservableHQ. The literate notebook can be run standalone or as Jupyter Notebook, JupyterLab, Visual Studio Code extension

--- a/packages/docusaurus/README.md
+++ b/packages/docusaurus/README.md
@@ -36,7 +36,7 @@ Add the following in any Markdown file.
 import JupyterCell from '@theme/JupyterCell';
 
 <JupyterCell 
-  src={`print('Hello world')
+  source={`print('Hello world')
 for i in range(10):
   print(i)
 `}


### PR DESCRIPTION
Tiny fixes 

- Add a link to the example 
- Fix a heading that wasn't rendering properly.
- Fix prop name in docs for docusaurus