### PR TITLE
Fix case sensitive imports

### DIFF
--- a/deprecated/prosemirror/tsconfig.json
+++ b/deprecated/prosemirror/tsconfig.json
@@ -7,6 +7,7 @@
     "**/node_modules"
   ],
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "baseUrl": "/",
     "rootDir": "./src",
     "allowSyntheticDefaultImports": true,

--- a/deprecated/slate/src/example/header/HeaderToolbar.tsx
+++ b/deprecated/slate/src/example/header/HeaderToolbar.tsx
@@ -3,7 +3,7 @@ import { alpha, styled } from '@mui/material/styles';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ToggleButton from '@mui/material/ToggleButton';
 import PlayArrowOutlined from '@mui/icons-material/PlayArrowOutlined';
-import PlayListPlay from '@mui/icons-material/PlayListPlay';
+import PlayListPlay from '@mui/icons-material/PlaylistPlay'
 import CleaningServices from '@mui/icons-material/CleaningServices';
 import Add from '@mui/icons-material/Add';
 import Delete from '@mui/icons-material/Delete';
@@ -132,7 +132,7 @@ const HeaderToolbar = ({ kernel, blockType, editor }: any) => {
           onChange={handleFormat}
           aria-label="text formatting"
         >
-          <ToggleButton 
+          <ToggleButton
             value="bold"
             aria-label="bold"
             disabled={blockType === null || blockType === ""}

--- a/deprecated/slate/src/example/popover/CellPopover.tsx
+++ b/deprecated/slate/src/example/popover/CellPopover.tsx
@@ -10,7 +10,7 @@ import { grey } from "@mui/material/colors";
 import Paper from "@mui/material/Paper";
 import PlayArrowOutlined from '@mui/icons-material/PlayArrowOutlined';
 import Add from '@mui/icons-material/Add';
-import PlayListPlay from '@mui/icons-material/PlayListPlay';
+import PlayListPlay from '@mui/icons-material/PlaylistPlay';
 import CleaningServices from '@mui/icons-material/CleaningServices';
 import { Portal } from "../../editor/components/Components";
 import { getBlockType } from "../../editor/utils/EditorUtils";

--- a/deprecated/slate/tsconfig.json
+++ b/deprecated/slate/tsconfig.json
@@ -7,6 +7,7 @@
     "**/node_modules"
   ],
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "rootDir": "./src",
     "allowSyntheticDefaultImports": true,

--- a/examples/create-react-app/tsconfig.json
+++ b/examples/create-react-app/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "target": "es5",
     "lib": [
       "dom",

--- a/examples/lexical/src/Editor.tsx
+++ b/examples/lexical/src/Editor.tsx
@@ -31,7 +31,7 @@ import ToolbarPlugin from "./plugins/ToolbarPlugin";
 import { useLexical } from "./context/LexicalContext";
 
 import "./Editor.css";
-import "./Rich.css";
+import "./rich.css";
 import "./Jupyter.css";
 
 type Props = {

--- a/examples/lexical/tsconfig.json
+++ b/examples/lexical/tsconfig.json
@@ -3,6 +3,7 @@
     "./src/**/*"
   ],
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "strict": true,
     "downlevelIteration": true,
     "esModuleInterop": true,

--- a/experiments/css/tsconfig.json
+++ b/experiments/css/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "target": "es2015",
     "module": "commonjs",
     "declaration": true,

--- a/experiments/esbuild/tsconfig.json
+++ b/experiments/esbuild/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,

--- a/experiments/ipyreactive/tsconfig.json
+++ b/experiments/ipyreactive/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "esModuleInterop":true,
     "lib": ["es2015", "dom"],

--- a/experiments/ipyscript/tsconfig.json
+++ b/experiments/ipyscript/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "esModuleInterop":true,
     "lib": ["es2015", "dom"],

--- a/experiments/jupyterlab/tsconfig.json
+++ b/experiments/jupyterlab/tsconfig.json
@@ -7,6 +7,7 @@
     "**/node_modules"
   ],
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "baseUrl": "/",
     "rootDir": "./src",
     "allowSyntheticDefaultImports": true,

--- a/experiments/themes/tsconfig.json
+++ b/experiments/themes/tsconfig.json
@@ -8,6 +8,7 @@
     "**/node_modules"
   ],
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "baseUrl": "/",
     "rootDir": "./src",
     "allowSyntheticDefaultImports": true,

--- a/packages/docusaurus/tsconfig.json
+++ b/packages/docusaurus/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "rootDir": "src",
     "outDir": "lib",

--- a/packages/lexical/src/index.tsx
+++ b/packages/lexical/src/index.tsx
@@ -3,8 +3,8 @@ export * from "./components/InsertEquationDialog";
 export * from "./components/InsertImageDialog";
 export * from "./components/JupyterOutputComponent";
 // Convert.
-export * from "./convert/LexicalToNbformat";
-export * from "./convert/NbformatToLexical";
+export * from "./convert/LexicalToNbFormat"
+export * from "./convert/NbFormatToLexical"
 // Hooks.
 export * from "./hooks/useModal";
 // Nodes.

--- a/packages/lexical/src/plugins/NbformatContentPlugin.tsx
+++ b/packages/lexical/src/plugins/NbformatContentPlugin.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { INotebookContent } from "@jupyterlab/nbformat";
-import { nbformatToLexical } from "../convert/NbformatToLexical";
+import { nbformatToLexical } from "../convert/NbFormatToLexical";
 
 type Props = {
   notebook?: INotebookContent

--- a/packages/lexical/tsconfig.json
+++ b/packages/lexical/tsconfig.json
@@ -8,6 +8,7 @@
     "**/node_modules"
   ],
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "baseUrl": "/",
     "rootDir": "./src",
     "allowSyntheticDefaultImports": true,

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -9,6 +9,7 @@
     "src/example"
   ],
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "baseUrl": "/",
     "rootDir": "./src",
     "allowSyntheticDefaultImports": true,

--- a/patches/jupyterlite-ipykernel-extension/tsconfigbase.json
+++ b/patches/jupyterlite-ipykernel-extension/tsconfigbase.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,

--- a/patches/jupyterlite-ipykernel/tsconfigbase.json
+++ b/patches/jupyterlite-ipykernel/tsconfigbase.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,

--- a/patches/jupyterlite-kernel/tsconfigbase.json
+++ b/patches/jupyterlite-kernel/tsconfigbase.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,

--- a/patches/jupyterlite-server-extension/tsconfigbase.json
+++ b/patches/jupyterlite-server-extension/tsconfigbase.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,

--- a/patches/jupyterlite-server/tsconfigbase.json
+++ b/patches/jupyterlite-server/tsconfigbase.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,

--- a/patches/jupyterlite-session/tsconfigbase.json
+++ b/patches/jupyterlite-session/tsconfigbase.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,

--- a/patches/jupyterlite-settings/tsconfigbase.json
+++ b/patches/jupyterlite-settings/tsconfigbase.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,


### PR DESCRIPTION
## Summary

This PR corrects some improper capitalization in a few imports which breaks the build on linux, and adds the `forceConsistentCasingInFileNames` to all `tsconfig.json` to hopefully avoid breaking builds in the future.

## Testing

I've done a clean build on my system and it built successfully.